### PR TITLE
AR-871: make array depend on rows and columns

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,15 @@
+on: pull_request
+name: Review
+jobs:
+  tests:
+    name: Test grid
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "16.x"
+      - name: install
+        run: yarn
+      - name: Run tests
+        run: yarn test

--- a/grid-generator.js
+++ b/grid-generator.js
@@ -1,5 +1,3 @@
-// const gridClasses = `grid ${horizontal}`;
-
 /**
  * @param {Array} gridArray
  *  The grid array.
@@ -42,7 +40,15 @@ function genCharArray(characterLength) {
  *   String of grid entries.
  */
 export function createGrid(columns, rows) {
-  const alphabet = genCharArray(3);
+  // So, the below determines how many entries in the grid area array
+  // So if there are 3 rows and 3 columns, it will be 0.3 rounded up to 1
+  // which means the array will contain the values a-z
+  // if there are 10 rows and 10 columns, the array will contain the values
+  // a-z, aa-zz, aaa-zzz, and aaaa-zzzz
+  const amountOfEnglishAlphabetLetters = 26;
+  const howManyEntriesInGrid =
+    Math.ceil((columns * rows) / amountOfEnglishAlphabetLetters);
+  const alphabet = genCharArray(howManyEntriesInGrid);
   const arrayOfGridTemplateAreas = new Array(columns);
   // Create two dimensional array.
   for (let i = 0; i < arrayOfGridTemplateAreas.length; i += 1) {

--- a/grid-generator.test.js
+++ b/grid-generator.test.js
@@ -1,21 +1,28 @@
-import { createGridArea, createGrid } from './grid-generator';
-test('Create grid area: from a to d', () => {
+import { createGridArea, createGrid } from "./grid-generator";
+test("Create grid area: from a to d", () => {
   expect(createGridArea(["a", "d"])).toBe("a / a / d / d");
 });
 
-test('Create grid area: from b to k', () => {
+test("Create grid area: from b to k", () => {
   expect(createGridArea(["b", "k"])).toBe("b / b / k / k");
 });
 
-test('Create grid area: from b to k with multiple array values', () => {
-  expect(createGridArea(["b","k","dd", "k"])).toBe("b / b / k / k");
+test("Create grid area: from b to k with multiple array values", () => {
+  expect(createGridArea(["b", "k", "dd", "k"])).toBe("b / b / k / k");
 });
 
-test('Create grid: 2x2', () => {
-  expect(createGrid(2,2)).toBe("'a b'\n 'c d'\n ");
+test("Create grid: 2x2", () => {
+  expect(createGrid(2, 2)).toBe("'a b'\n 'c d'\n ");
 });
 
-test('Create grid: 10x2', () => {
-  console.log(createGrid(10,2))
-  expect(createGrid(10,2)).toBe("'a b'\n 'c d'\n 'e f'\n 'g h'\n 'i j'\n 'k l'\n 'm n'\n 'o p'\n 'q r'\n 's t'\n ");
+test("Create grid: 10x2", () => {
+  expect(createGrid(10, 2)).toBe(
+    "'a b'\n 'c d'\n 'e f'\n 'g h'\n 'i j'\n 'k l'\n 'm n'\n 'o p'\n 'q r'\n 's t'\n "
+  );
+});
+
+test("it works with large grids", () => {
+  expect(createGrid(44, 4)).toBe(
+    "'a b c d'\n 'e f g h'\n 'i j k l'\n 'm n o p'\n 'q r s t'\n 'u v w x'\n 'y z aa bb'\n 'cc dd ee ff'\n 'gg hh ii jj'\n 'kk ll mm nn'\n 'oo pp qq rr'\n 'ss tt uu vv'\n 'ww xx yy zz'\n 'aaa bbb ccc ddd'\n 'eee fff ggg hhh'\n 'iii jjj kkk lll'\n 'mmm nnn ooo ppp'\n 'qqq rrr sss ttt'\n 'uuu vvv www xxx'\n 'yyy zzz aaaa bbbb'\n 'cccc dddd eeee ffff'\n 'gggg hhhh iiii jjjj'\n 'kkkk llll mmmm nnnn'\n 'oooo pppp qqqq rrrr'\n 'ssss tttt uuuu vvvv'\n 'wwww xxxx yyyy zzzz'\n 'aaaaa bbbbb ccccc ddddd'\n 'eeeee fffff ggggg hhhhh'\n 'iiiii jjjjj kkkkk lllll'\n 'mmmmm nnnnn ooooo ppppp'\n 'qqqqq rrrrr sssss ttttt'\n 'uuuuu vvvvv wwwww xxxxx'\n 'yyyyy zzzzz aaaaaa bbbbbb'\n 'cccccc dddddd eeeeee ffffff'\n 'gggggg hhhhhh iiiiii jjjjjj'\n 'kkkkkk llllll mmmmmm nnnnnn'\n 'oooooo pppppp qqqqqq rrrrrr'\n 'ssssss tttttt uuuuuu vvvvvv'\n 'wwwwww xxxxxx yyyyyy zzzzzz'\n 'aaaaaaa bbbbbbb ccccccc ddddddd'\n 'eeeeeee fffffff ggggggg hhhhhhh'\n 'iiiiiii jjjjjjj kkkkkkk lllllll'\n 'mmmmmmm nnnnnnn ooooooo ppppppp'\n 'qqqqqqq rrrrrrr sssssss ttttttt'\n "
+  );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1582,9 +1582,9 @@ camelcase@^6.2.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001248:
-  version "1.0.30001249"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz"
-  integrity sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==
+  version "1.0.30001425"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001425.tgz"
+  integrity sha512-/pzFv0OmNG6W0ym80P3NtapU0QEiDS3VuYAZMGoLLqiC7f6FJFe1MjpQDREGApeenD9wloeytmVDj+JLXPC6qw==
 
 chalk@^2.0.0:
   version "2.4.2"


### PR DESCRIPTION
https://jira.itkdev.dk/browse/AR-871 

The grid generator has to be more "fine-grained", so it needs more entries in the array of grid areas. I made it depend on the row/column-input (which i probably should have to begin with instead of hardcoded "3")

Added tests

Updated browserlists

added pr.yml

<img width="436" alt="image" src="https://user-images.githubusercontent.com/15377965/197710241-0f59d169-3313-461d-b199-f176fcc201e5.png">
